### PR TITLE
DO-7051: Create account_status local hook trigger

### DIFF
--- a/database/create_pgsql_schema.sql
+++ b/database/create_pgsql_schema.sql
@@ -50,6 +50,7 @@ SELECT schema_support.build_audit_tables('audit', 'jazzhands');
 
 \ir ddl/schema/pgsql/create_account_coll_hier_triggers.sql
 \ir ddl/schema/pgsql/create_account_triggers.sql
+\ir ddl/schema/pgsql/create_account_hook_triggers.sql
 \ir ddl/schema/pgsql/create_acct_coll_report_triggers.sql
 \ir ddl/schema/pgsql/create_approval_triggers.sql
 \ir ddl/schema/pgsql/create_auto_account_coll_triggers.sql

--- a/database/ddl/schema/pgsql/create_account_hook_triggers.sql
+++ b/database/ddl/schema/pgsql/create_account_hook_triggers.sql
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2016 Todd Kover
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+CREATE OR REPLACE FUNCTION account_status_after_hooks()
+RETURNS TRIGGER AS $$
+BEGIN
+	BEGIN
+		PERFORM local_hooks.account_status_after_hooks();
+	EXCEPTION WHEN invalid_schema_name OR undefined_function THEN
+		PERFORM 1;
+	END;
+	RETURN NULL;
+END;
+$$
+LANGUAGE plpgsql SECURITY DEFINER
+SET search_path=jazzhands;
+
+DROP TRIGGER IF EXISTS trigger_account_status_after_hooks
+	ON account;
+CREATE TRIGGER trigger_account_status_after_hooks
+AFTER UPDATE of account_status
+	ON account
+	FOR EACH ROW EXECUTE PROCEDURE account_status_after_hooks();
+


### PR DESCRIPTION
**Purpose**: Support a local_hook for UPDATEs to `jazzhands.account.account_status`.

**Tasks**:
- [x] test with no `local_hooks` schema
- [x] test with `local_hooks` schema
- [x] `pg_dump --schema-only` and diff between current version and patch

**Testing**:
I'm leveraging the [official postgresql Docker image](https://hub.docker.com/_/postgres/) version `9.5` to have a clean db. My environment set up can be found here: https://gist.github.com/nguyening/89b4feb802660ce934bcd5905c2e1b65

I'm verifying my changes by using the `database/create_and_test_pgsql.sql` script.
Output from my test runs can be found here:
https://gist.github.com/nguyening/c51743d88e88058f50cb5b48cff48a1c