### PR TITLE
DO-7051: Pass affected account record as argument to local hook

### DIFF
--- a/database/ddl/schema/pgsql/create_account_hook_triggers.sql
+++ b/database/ddl/schema/pgsql/create_account_hook_triggers.sql
@@ -16,11 +16,11 @@
  */
 
 
-CREATE OR REPLACE FUNCTION account_status_after_hooks()
+CREATE OR REPLACE FUNCTION account_status_per_row_after_hooks()
 RETURNS TRIGGER AS $$
 BEGIN
 	BEGIN
-		PERFORM local_hooks.account_status_after_hooks();
+		PERFORM local_hooks.account_status_per_row_after_hooks(account_record => NEW);
 	EXCEPTION WHEN invalid_schema_name OR undefined_function THEN
 		PERFORM 1;
 	END;
@@ -30,10 +30,10 @@ $$
 LANGUAGE plpgsql SECURITY DEFINER
 SET search_path=jazzhands;
 
-DROP TRIGGER IF EXISTS trigger_account_status_after_hooks
+DROP TRIGGER IF EXISTS trigger_account_status_per_row_after_hooks
 	ON account;
-CREATE TRIGGER trigger_account_status_after_hooks
+CREATE TRIGGER trigger_account_status_per_row_after_hooks
 AFTER UPDATE of account_status
 	ON account
-	FOR EACH ROW EXECUTE PROCEDURE account_status_after_hooks();
+	FOR EACH ROW EXECUTE PROCEDURE account_status_per_row_after_hooks();
 


### PR DESCRIPTION
**Purpose**: Pass affected account as an argument to local hook functions when UPDATEs happen on `jazzhands.account.account_status`.

**Tasks**:
- [x] test with no `local_hooks` schema
- [x] test with `local_hooks` schema
- [x] `pg_dump --schema-only` and diff between current version and patch

**Testing**:
Same deal as: https://github.com/JazzHandsCMDB/jazzhands/pull/1

Output from my test runs can be found here:
https://gist.github.com/nguyening/05c329042e9d96c2426e8985575b9263