### PR TITLE
Fix dhcpgen build

### DIFF
--- a/management/dhcpgen/debian/changelog
+++ b/management/dhcpgen/debian/changelog
@@ -1,3 +1,9 @@
+jazzhands-dhcpgen (0.95.8.1) trusty; urgency=medium
+
+  * Fix package building
+
+ -- Thomas Avril <github@contact.avril.name>  Thu, 01 Jun 2023 14:06:14 +0000
+
 jazzhands-dhcpgen (0.95.8) trusty; urgency=medium
 
   * No need to daemonize anymore. Systemd will do it.

--- a/management/dhcpgen/debian/control
+++ b/management/dhcpgen/debian/control
@@ -2,7 +2,7 @@ Source: jazzhands-dhcpgen
 Section: System/Management
 Priority: optional
 Maintainer: Matthew Ragan <mdr@sucksless.net>
-Build-Depends: debhelper (>= 8.0.0)
+Build-Depends: debhelper (>= 8.0.0), base-files (>= 12ubuntu4) | dh-systemd (>= 1.5)
 Standards-Version: 3.9.4
 
 Package: jazzhands-dhcpgen


### PR DESCRIPTION
For Ubuntu < 18.04, we need to specify dh-systemd as a build dependency if your package ship a systemd service (not required with Ubuntu 18.04+)