### PR TITLE
Added support for 24.04

### DIFF
--- a/management/appauthal/python/debian/changelog
+++ b/management/appauthal/python/debian/changelog
@@ -1,3 +1,9 @@
+python-jazzhands-appauthal (0.98.1) bionic; urgency=medium
+
+  * Added support for 24.04
+
+ -- Stephane Messerli <stephane.messerli@polypode.org>  Fri, 16 Aug 2024 14:32:00 +0200
+
 python-jazzhands-appauthal (0.96.0) bionic; urgency=medium
 
   * bump up various debian versions of things to be currentish

--- a/management/appauthal/python/debian/control
+++ b/management/appauthal/python/debian/control
@@ -2,7 +2,7 @@ Source: python-jazzhands-appauthal
 Section: unknown
 Priority: extra
 Maintainer: JazzHands Project <release@jazzhands.net>
-Build-Depends: debhelper (>= 9.0.0), python-all, python-setuptools, python3-all, python3-setuptools, dh-python
+Build-Depends: debhelper (>= 9.0.0), lsb-release, base-files (>= 13ubuntu10) | python-all, base-files (>= 13ubuntu10) | python-setuptools, python3-all, python3-setuptools, dh-python
 Standards-Version: 4.6.2
 X-Python-Version: >= 2.7
 X-Python3-Version: >= 3.4

--- a/management/appauthal/python/debian/rules
+++ b/management/appauthal/python/debian/rules
@@ -7,6 +7,21 @@
 DPKG_EXPORT_BUILDFLAGS = 1
 include /usr/share/dpkg/default.mk
 export PYBUILD_NAME = jazzhands-appauthal
+CODENAME=$(shell lsb_release -sc )
+
+PYTHON_VERSIONS = "python3"
+ifeq "$(CODENAME)" "xenial"
+	PYTHON_VERSIONS = "python3,python2"
+endif
+ifeq "$(CODENAME)" "bionic"
+	PYTHON_VERSIONS = "python3,python2"
+endif
+ifeq "$(CODENAME)" "focal"
+	PYTHON_VERSIONS = "python3,python2"
+endif
+ifeq "$(CODENAME)" "jammy"
+	PYTHON_VERSIONS = "python3,python2"
+endif
 
 %:
-	dh $@ --with python3,python2 --buildsystem=pybuild
+	dh $@ --with $(PYTHON_VERSIONS) --buildsystem=pybuild

--- a/management/appauthal/python/setup.py
+++ b/management/appauthal/python/setup.py
@@ -14,10 +14,13 @@
 # limitations under the License.
 
 import subprocess
-from distutils.core import setup
+try:
+    from setuptools import setup
+except ImportError:
+    from distutils.core import setup
 
 # this should be pulled in automatically
-version = '0.90.13'
+version = '0.98.0'
 
 classifiers = [
     "Topic :: Utilities",

--- a/management/util/python-vault/debian/changelog
+++ b/management/util/python-vault/debian/changelog
@@ -1,3 +1,9 @@
+python-jazzhands-vault (0.98.1) bionic; urgency=medium
+
+  * Added support for 24.04
+
+ -- Stephane Messerli <stephane.messerli@polypode.org>  Mon, 19 Aug 2024 11:57:00 +0200
+
 python-jazzhands-vault (0.96.0) bionic; urgency=medium
 
   * bump up various debian versions of things to be currentish

--- a/management/util/python-vault/debian/control
+++ b/management/util/python-vault/debian/control
@@ -2,7 +2,7 @@ Source: python-jazzhands-vault
 Section: unknown
 Priority: extra
 Maintainer: JazzHands Project <release@jazzhands.net>
-Build-Depends: debhelper (>= 9.0.0), python-all, python-setuptools, python3-all, python3-setuptools, dh-python
+Build-Depends: debhelper (>= 9.0.0), lsb-release, base-files (>= 13ubuntu10) | python-all, base-files (>= 13ubuntu10) | python-setuptools, python3-all, python3-setuptools, dh-python
 Standards-Version: 4.6.2
 X-Python-Version: >= 2.7
 X-Python3-Version: >= 3.4

--- a/management/util/python-vault/debian/rules
+++ b/management/util/python-vault/debian/rules
@@ -6,6 +6,21 @@ export DH_VERBOSE=1
 # see EXAMPLES in dpkg-buildflags(1) and read /usr/share/dpkg/*
 DPKG_EXPORT_BUILDFLAGS = 1
 export PYBUILD_NAME = jazzhands-vault
+CODENAME=$(shell lsb_release -sc )
+
+PYTHON_VERSIONS = "python3"
+ifeq "$(CODENAME)" "xenial"
+       PYTHON_VERSIONS = "python3,python2"
+endif
+ifeq "$(CODENAME)" "bionic"
+       PYTHON_VERSIONS = "python3,python2"
+endif
+ifeq "$(CODENAME)" "focal"
+       PYTHON_VERSIONS = "python3,python2"
+endif
+ifeq "$(CODENAME)" "jammy"
+       PYTHON_VERSIONS = "python3,python2"
+endif
 
 %:
-	dh $@ --with python3,python2 --buildsystem=pybuild
+	dh $@ --with $(PYTHON_VERSIONS) --buildsystem=pybuild

--- a/management/util/python-vault/setup.py
+++ b/management/util/python-vault/setup.py
@@ -14,10 +14,13 @@
 # limitations under the License.
 
 import subprocess
-from distutils.core import setup
+try:
+    from setuptools import setup
+except ImportError:
+    from distutils.core import setup
 
 # this should be pulled in automatically
-version = '0.93.0'
+version = '0.98.1'
 
 classifiers = [
     "Topic :: Utilities",


### PR DESCRIPTION
This is a build recipe fix for python-jazzhands-appauthal and python-jazzhands-vault on 24.04, which doesn't support python2 at all anymore.

The produced packages have no change to the contained py files. For example, comparing the last 3 releases for python and python3 for 22.04 for python-jazzhands-appauthal:

```
$ md5sum python3-jazzhands-appauthal_*/usr/lib/python3/dist-packages/jazzhands_appauthal/appauthal.py
262a53f95ba0102e8118ae8eab9513d9  python3-jazzhands-appauthal_0.90.13-1_amd64/usr/lib/python3/dist-packages/jazzhands_appauthal/appauthal.py
262a53f95ba0102e8118ae8eab9513d9  python3-jazzhands-appauthal_0.96.0-1_all/usr/lib/python3/dist-packages/jazzhands_appauthal/appauthal.py
262a53f95ba0102e8118ae8eab9513d9  python3-jazzhands-appauthal_0.98.1-1_all/usr/lib/python3/dist-packages/jazzhands_appauthal/appauthal.py

$ md5sum python-jazzhands-appauthal_*/usr/lib/python2.7/dist-packages/jazzhands_appauthal/appauthal.py
262a53f95ba0102e8118ae8eab9513d9  python-jazzhands-appauthal_0.90.13-1_amd64/usr/lib/python2.7/dist-packages/jazzhands_appauthal/appauthal.py
262a53f95ba0102e8118ae8eab9513d9  python-jazzhands-appauthal_0.96.0-1_all/usr/lib/python2.7/dist-packages/jazzhands_appauthal/appauthal.py
262a53f95ba0102e8118ae8eab9513d9  python-jazzhands-appauthal_0.98.1-1_all/usr/lib/python2.7/dist-packages/jazzhands_appauthal/appauthal.py
```

Same result for the python-jazzhands-vault package, this time just for the python3 package:
```
$ md5sum python3-jazzhands-vault_0.9*.22.04/usr/lib/python*/dist-packages/jazzhands_vault/vault.py
96728db90dd4f1eaa1419ade8dce36a0  python3-jazzhands-vault_0.93.0-1_amd64.22.04/usr/lib/python3/dist-packages/jazzhands_vault/vault.py
96728db90dd4f1eaa1419ade8dce36a0  python3-jazzhands-vault_0.96.0-1_all.22.04/usr/lib/python3/dist-packages/jazzhands_vault/vault.py
96728db90dd4f1eaa1419ade8dce36a0  python3-jazzhands-vault_0.98.1-1_all.22.04/usr/lib/python3/dist-packages/jazzhands_vault/vault.py
```

This proves that the build recipe changes didn't impact the actual content of the package.