### PR TITLE
Fix display of DNS zone with no record

### DIFF
--- a/management/stab/debian/changelog
+++ b/management/stab/debian/changelog
@@ -1,3 +1,9 @@
+jazzhands-stab (0.98.1) jammy; urgency=medium
+
+  * Fixed error when displaying DNS zone with no record
+
+ -- Stephane Messerli <stephane.messerli@polypode.org>  Mon, 18 Nov 2024 15:34:00 +0100
+
 jazzhands-stab (0.98.0) jammy; urgency=medium
 
   * Upgraded dataTables third-party module from 1.10.9 to 2.0.3 to get support for dark themes on the X509 certificates pages

--- a/management/stab/debian/changelog
+++ b/management/stab/debian/changelog
@@ -1,6 +1,7 @@
 jazzhands-stab (0.98.1) jammy; urgency=medium
 
   * Fixed error when displaying DNS zone with no record
+  * Make rack PDU name background darker in dark mode
 
  -- Stephane Messerli <stephane.messerli@polypode.org>  Mon, 18 Nov 2024 15:34:00 +0100
 

--- a/management/stab/web/src/web/css/stab.css
+++ b/management/stab/web/src/web/css/stab.css
@@ -47,6 +47,7 @@
 
 		--background-rackit-even: #FFFF33;
 		--background-rackit-odd: #FFAA33;
+		--background-rackit-vertical: lightgray;
 
 		--icon-vendor-filter: brightness(1.0);
 
@@ -106,6 +107,7 @@
 
 		--background-rackit-even: #4a4834;
 		--background-rackit-odd: #433528;
+		--background-rackit-vertical: #555;
 
 		--icon-vendor-filter: brightness(1.0);
 
@@ -553,7 +555,7 @@ td.rackit_vertical {
 	width: 10px;
 	text-align: center;
 	border: 1px solid black;
-	background: lightgrey;
+	background: var(--background-rackit-vertical);
 }
 
 img.icon-vendor {

--- a/management/stab/web/src/web/dns/index.pl
+++ b/management/stab/web/src/web/dns/index.pl
@@ -1038,8 +1038,8 @@ sub validate_page {
 	my $pages = ceil( $count / $paging_dns_limit );
 
 	# Make sure the page is within the range of pages
-	$paging_dns_page = 1      if $paging_dns_page < 1;
 	$paging_dns_page = $pages if $paging_dns_page > $pages;
+	$paging_dns_page = 1      if $paging_dns_page < 1;
 
 	$paging_dns_page;
 }


### PR DESCRIPTION
Attempting to display a DNS zone with no records fails with a database error.
Two paging validation checks have to be swapped to fix this issue.